### PR TITLE
workflow config and database reliability [imp]

### DIFF
--- a/bioinformatics_tools/api/routers/ssh.py
+++ b/bioinformatics_tools/api/routers/ssh.py
@@ -155,17 +155,17 @@ async def create_default_config(current_user: dict = Depends(get_current_user)):
     default_config = {
         "main_database": "~/.local/share/bioinformatics-tools/my-db.db",
         "compute": {
-            "cluster-default": {}
+            "cluster_default": {}
         }
     }
 
-    # Populate compute.cluster-default with all defaults from REQUIRED_SYSTEM_PARAMS
+    # Populate compute.cluster_default with all defaults from REQUIRED_SYSTEM_PARAMS
     for param in REQUIRED_SYSTEM_PARAMS:
-        if param['param'].startswith('compute.cluster-default.'):
+        if param['param'].startswith('compute.cluster_default.'):
             key = param['param'].split('.')[-1]  # Extract the last part (e.g., 'account', 'partition')
             default_value = param.get('default')
             # Use empty string for required fields with no default, otherwise use the default
-            default_config['compute']['cluster-default'][key] = default_value if default_value is not None else ""
+            default_config['compute']['cluster_default'][key] = default_value if default_value is not None else ""
 
     try:
         ssh_sftp.write_remote_yaml(path, default_config, connection=conn)
@@ -281,10 +281,10 @@ async def run_workflow(genome_data: GenomeSend, current_user: dict = Depends(get
     if not main_db or str(main_db).strip() == '':
         missing_fields.append('main_database')
 
-    # Check compute.cluster-default.account
-    account = user_config.get('compute', {}).get('cluster-default', {}).get('account')
+    # Check compute.cluster_default.account
+    account = user_config.get('compute', {}).get('cluster_default', {}).get('account')
     if not account or str(account).strip() == '':
-        missing_fields.append('compute.cluster-default.account (SLURM account)')
+        missing_fields.append('compute.cluster_default.account (SLURM account)')
 
     if missing_fields:
         raise HTTPException(

--- a/bioinformatics_tools/caragols/clix.py
+++ b/bioinformatics_tools/caragols/clix.py
@@ -157,7 +157,11 @@ class App:
         if not config_files:
             LOGGER.warning('No configuration files found!')
             self.conf = nuconf  # Return BLANK config
+            self.config_paths = []  # Store empty list
             return
+
+        # Store config file paths for later use (e.g., passing to Snakemake)
+        self.config_paths = config_files
 
         for conf in config_files:
             try:

--- a/bioinformatics_tools/caragols/condo.py
+++ b/bioinformatics_tools/caragols/condo.py
@@ -482,6 +482,24 @@ class CxNode(object):
                 d[str(k.head)] = self[k.head].toJDN()
         return d
 
+    def to_nested_dict(self):
+        """
+        Convert CxNode to a proper nested Python dictionary.
+
+        Unlike .flattened which creates flat keys with dots (e.g., 'compute.cluster_default.account'),
+        this returns a proper nested dict structure: {'compute': {'cluster_default': {'account': ...}}}
+
+        Returns:
+            dict: Nested dictionary representation of the configuration
+        """
+        result = {}
+        for k, v in self.children.items():
+            if isinstance(v, CxNode):
+                result[k] = v.to_nested_dict()  # Recursive for nested CxNodes
+            else:
+                result[k] = v
+        return result
+
 
 def Condex(*args, **kwargs):
     c = CxNode()

--- a/bioinformatics_tools/caragols/config-template.yaml
+++ b/bioinformatics_tools/caragols/config-template.yaml
@@ -1,7 +1,7 @@
 report:
   form: prose 
 
-maintenance-info:
+maintenance_info:
   version: 1
   description: 'This is the default configuration file'
   contact: 'https://github.com/Diet-Microbiome-Interactions-Lab/GeneralTools/issues'

--- a/bioinformatics_tools/workflow_tools/margie.smk
+++ b/bioinformatics_tools/workflow_tools/margie.smk
@@ -2,72 +2,36 @@
 All MARGIE rules. No games.
 """
 import os
+import sys
+
+# Add current directory to path to import workflow_helpers
+sys.path.insert(0, os.path.dirname(workflow.snakefile))
+from workflow_helpers import rc, fixed_path, tool_output, db_token
 
 WORKFLOW_DIR = os.path.dirname(workflow.snakefile)
 
-def rc(rule_name, param=None, default=None):
-    """
-    Rule Config: Get config value for a specific rule's parameter.
-
-    Supports both nested and top-level config patterns:
-
-    Example configs:
-        # Nested (for tool parameters)
-        prodigal:
-          threads: 1
-          mem_mb: 2048
-
-        # Top-level (for simple values)
-        mykey: value
-
-    Usage in rules:
-        threads: rc('prodigal', 'threads', 1)   # nested lookup
-        value: rc('mykey', default='fallback')  # top-level lookup
-
-    Args:
-        rule_name: The tool name or config key
-        param: Parameter name (optional, for nested configs)
-        default: Default value if not found in config
-
-    Returns:
-        The config value or default if not set
-    """
-    # Use global config (available in all Snakemake files)
-    # This is more reliable than workflow.config during rule definition
-
-    # If param is None, lookup rule_name as a top-level key
-    if param is None:
-        return config.get(rule_name, default)
-
-    # Try nested lookup: config[rule_name][param]
-    rule_config = config.get(rule_name, {})
-    if isinstance(rule_config, dict):
-        return rule_config.get(param, default)
-
-    return default
-
 rule all:
     input:
-        config.get('out_prodigal_db', 'prodigal_db.tkn'),
-        config.get('out_pfam_db', 'pfam_db.tkn'),
-        config.get('out_cog_db', 'cog_db.tkn'),
-        config.get('out_kofam_db', 'kofam/kofam_db.tkn'),
-        config.get('out_uniop_db', 'uniop/uniop_db.tkn'),
-        config.get('out_dbcan_db', 'dbcan/dbcan_db.tkn')
+        db_token('prodigal', config=config),
+        db_token('pfam', config=config),
+        db_token('cog', config=config),
+        db_token('kofam', config=config),
+        db_token('uniop', config=config),
+        db_token('dbcan', config=config)
 
 
 rule run_prodigal:
     """prodigal"""
     input:
-        config.get('input_fasta')
+        rc('input_fasta', config=config)
     output:
-        gff=config.get('out_prodigal_gff', 'prodigal/prodigal.tkn'),
-        faa=config.get('out_prodigal_faa', 'prodigal/prodigal.faa')
+        gff=tool_output('prodigal.output', 'gff', config=config),
+        faa=tool_output('prodigal.output', 'faa', config=config)
     group: "prodigal"
-    threads: rc('prodigal', 'threads', 1)
+    threads: rc('prodigal.threads', 1, config=config)
     resources:
-        mem_mb=rc('prodigal', 'mem_mb', 2048),
-        runtime=rc('prodigal', 'runtime', 30)
+        mem_mb=rc('prodigal.mem_mb', 2048, config=config),
+        runtime=rc('prodigal.runtime', 30, config=config)
     container: "~/.cache/bioinformatics-tools/prodigal.sif"
     shell:
         """
@@ -78,12 +42,12 @@ rule run_prodigal:
 rule load_prodigal_to_db:
     """Load prodigal GFF output into SQLite database"""
     input:
-        gff=config.get('out_prodigal', 'prodigal/prodigal.tkn')
+        gff=tool_output('prodigal.output', 'gff', config=config)
     output:
-        tkn=config.get('out_prodigal_db', 'prodigal/prodigal_db.tkn')
+        tkn=db_token('prodigal', config=config)
     group: "prodigal"
     params:
-        db=config['main_database'],  # Required - no fallback
+        db=rc('main_database', config=config),  # TODO: Add specific error if main_database is not set
         script=os.path.join(WORKFLOW_DIR, "load_to_db.py")
     shell:
         """
@@ -93,17 +57,17 @@ rule load_prodigal_to_db:
 
 rule run_pfam:
     input:
-        config.get('out_prodigal_faa', '/home/ddeemer/smallish.faa')
+        tool_output('prodigal.output', 'faa', config=config)
     output:
-        config.get('out_pfam', 'pfam/pfam.tkn')
+        fixed_path('pfam', 'pfam.tsv', use_stem=False, config=config)
     group: "pfam"
     container: "~/.cache/bioinformatics-tools/pfam_scan_light.sif"
-    threads: rc('pfam', 'threads', 4)
+    threads: rc('pfam.threads', 4, config=config)
     resources:
-        mem_mb=rc('pfam', 'mem_mb', 4000),
-        runtime=rc('pfam', 'runtime', 240)
+        mem_mb=rc('pfam.mem_mb', 4000, config=config),
+        runtime=rc('pfam.runtime', 240, config=config)
     params:
-        db=rc('pfam', 'db', "/depot/lindems/data/Databases/pfam")
+        db=rc('pfam.db', "/depot/lindems/data/Databases/pfam", config=config)
     shell:
         """
         pfam_scan.py {input} {params.db} -out {output} -cpu {threads}
@@ -113,12 +77,12 @@ rule run_pfam:
 rule load_pfam_to_db:
     """Load pfam CSV output into SQLite database"""
     input:
-        csv=config.get('out_pfam', 'pfam/pfam.tkn')
+        csv=fixed_path('pfam', 'pfam.tsv', use_stem=False, config=config)
     output:
-        tkn=config.get('out_pfam_db', 'pfam/pfam_db.tkn')
+        tkn=db_token('pfam', config=config)
     group: "pfam"
     params:
-        db=config['main_database'],  # Required - no fallback
+        db=rc('main_database', config=config),  # TODO: Add specific error if main_database is not set
         script=os.path.join(WORKFLOW_DIR, "load_to_db.py")
     shell:
         """
@@ -129,19 +93,19 @@ rule load_pfam_to_db:
 rule run_cog:
     """COGclassifier - classify proteins into COG functional categories"""
     input:
-        faa=config.get('out_prodigal_faa')
+        faa=tool_output('prodigal.output', 'faa', config=config)
     output:
-        classify=config.get('out_cog_classify', 'cog/cog_classify.tsv'),
-        counts=config.get('out_cog_count', 'cog/cog_count.tsv'),
-        tkn=config.get('out_cog', 'cog/cog.tkn')
+        classify=fixed_path('cog', 'cog_classify.tsv', use_stem=False, config=config),
+        counts=fixed_path('cog', 'cog_count.tsv', use_stem=False, config=config),
+        tkn=fixed_path('cog', 'cog.tkn', use_stem=False, config=config)
     group: "cog"
     params:
-        outdir=rc('cog', 'outdir', 'cog'),
-        db=rc('cog', 'db', '/depot/lindems/data/Databases/cog/')
-    threads: rc('cog', 'threads', 4)
+        outdir=rc('cog.outdir', 'cog', config=config),
+        db=rc('cog.db', '/depot/lindems/data/Databases/cog/', config=config)
+    threads: rc('cog.threads', 4, config=config)
     resources:
-        mem_mb=rc('cog', 'mem_mb', 8192),
-        runtime=rc('cog', 'runtime', 120)
+        mem_mb=rc('cog.mem_mb', 8192, config=config),
+        runtime=rc('cog.runtime', 120, config=config)
     container: "~/.cache/bioinformatics-tools/cogclassifier.sif"
     shell:  # TODO: Remove this copy command
         """
@@ -155,13 +119,13 @@ rule run_cog:
 rule load_cog_to_db:
     """Load COGclassifier TSV output into SQLite database"""
     input:
-        classify=config.get('out_cog_classify', 'cog/cog_classify.tsv'),
-        counts=config.get('out_cog_count', 'cog/cog_count.tsv')
+        classify=fixed_path('cog', 'cog_classify.tsv', use_stem=False, config=config),
+        counts=fixed_path('cog', 'cog_count.tsv', use_stem=False, config=config)
     output:
-        tkn=config.get('out_cog_db', 'cog/cog_db.tkn')
+        tkn=db_token('cog', config=config)
     group: "cog"
     params:
-        db=config['main_database'],  # Required - no fallback
+        db=rc('main_database', config=config),  # TODO: Add specific error if main_database is not set
         script=os.path.join(WORKFLOW_DIR, "load_to_db.py")
     shell:
         """
@@ -172,18 +136,18 @@ rule load_cog_to_db:
 
 rule run_kofam:
     input:
-        faa=config.get('out_prodigal_faa')
+        faa=tool_output('prodigal.output', 'faa', config=config)
     output:
-        results=config.get('out_kofam', 'kofam/kofam.tkn')
+        results=fixed_path('kofam', 'kofam.tsv', use_stem=False, config=config)
     container: "~/.cache/bioinformatics-tools/kofam_scan_light_bsp.sif"
-    threads: rc('kofam', 'threads', 16)
+    threads: rc('kofam.threads', 16, config=config)
     resources:
-        mem_mb=rc('kofam', 'mem_mb', 4000),
-        runtime=rc('kofam', 'runtime', 180)
+        mem_mb=rc('kofam.mem_mb', 4000, config=config),
+        runtime=rc('kofam.runtime', 180, config=config)
     group: "kofam"
     params:
-        profile_db=rc('kofam', 'profile_db', "/depot/lindems/data/Databases/kofams/profiles"),
-        ko_list=rc('kofam', 'ko_list', "/depot/lindems/data/Databases/kofams/ko_list")
+        profile_db=rc('kofam.profile_db', "/depot/lindems/data/Databases/kofams/profiles", config=config),
+        ko_list=rc('kofam.ko_list', "/depot/lindems/data/Databases/kofams/ko_list", config=config)
     shell:
         """
         exec_annotation {input.faa} -o {output.results} --profile {params.profile_db} --ko-list {params.ko_list} \
@@ -193,12 +157,12 @@ rule run_kofam:
 rule load_kofam_to_db:
     """Load KOFam_Scan output into SQLite database"""
     input:
-        results=config.get('out_kofam'),
+        results=fixed_path('kofam', 'kofam.tsv', use_stem=False, config=config)
     output:
-        tkn=config.get('out_kofam_db', 'kofam/kofam_db.tkn')
+        tkn=db_token('kofam', config=config)
     group: "kofam"
     params:
-        db=config['main_database'],  # Required - no fallback
+        db=rc('main_database', config=config),  # TODO: Add specific error if main_database is not set
         script=os.path.join(WORKFLOW_DIR, "load_to_db.py")
     shell:
         """
@@ -209,33 +173,33 @@ rule load_kofam_to_db:
 rule run_uniop:
     """Operon prediction using operon_exec"""
     input:
-        faa=config.get('out_prodigal_faa')
+        faa=tool_output('prodigal.output', 'faa', config=config)
     output:
-        operons=config.get('out_uniop', 'uniop/operons.tsv')
+        operons=fixed_path('uniop', 'operons.tsv', use_stem=False, config=config)
     group: "uniop"
-    threads: rc('uniop', 'threads', 4)
+    threads: rc('uniop.threads', 4, config=config)
     resources:
-        mem_mb=rc('uniop', 'mem_mb', 4000),
-        runtime=rc('uniop', 'runtime', 120)
+        mem_mb=rc('uniop.mem_mb', 4000, config=config),
+        runtime=rc('uniop.runtime', 120, config=config)
     params:
-        output_dir=rc('uniop', 'output_dir', 'uniop')
+        output_dir=rc('uniop.output_dir', 'uniop', config=config)
     container: "~/.cache/bioinformatics-tools/opr-dev.sif"
     shell:
         """
         operon_exec -i {input.faa} -o {params.output_dir}
-        find {params.output_dir} -name "operons.tsv" -exec cp {{}} {output.operons} \;
+        cp $(find {params.output_dir} -name "operons.tsv") {output.operons}
         """
 
 
 rule load_uniop_to_db:
     """Load operon prediction results into SQLite database"""
     input:
-        operons=config.get('out_uniop', 'uniop/operons.tsv')
+        operons=fixed_path('uniop', 'operons.tsv', use_stem=False, config=config)
     output:
-        tkn=config.get('out_uniop_db', 'uniop/uniop_db.tkn')
+        tkn=db_token('uniop', config=config)
     group: "uniop"
     params:
-        db=config['main_database'],  # Required - no fallback
+        db=rc('main_database', config=config),  # TODO: Add specific error if main_database is not set
         script=os.path.join(WORKFLOW_DIR, "load_to_db.py")
     shell:
         """
@@ -246,17 +210,17 @@ rule load_uniop_to_db:
 rule run_dbcan:
     """dbCAN - CAZyme annotation and CGC prediction"""
     input:
-        fasta=rc('input_fasta')
+        fasta=rc('input_fasta', config=config)
     output:
-        overview=config.get('out_dbcan', 'dbcan/overview.tsv')
+        overview=fixed_path('dbcan', 'overview.tsv', use_stem=False, config=config)
     group: "dbcan"
-    threads: rc('dbcan', 'threads', 4)
+    threads: rc('dbcan.threads', 4, config=config)
     resources:
-        mem_mb=rc('dbcan', 'mem_mb', 7984),
-        runtime=rc('dbcan', 'runtime', 180)
+        mem_mb=rc('dbcan.mem_mb', 7984, config=config),
+        runtime=rc('dbcan.runtime', 180, config=config)
     params:
-        output_dir=rc('dbcan', 'output_dir', 'dbcan'),
-        db=rc('dbcan', 'db', "/depot/lindems/data/Databases/cazyme/db")
+        output_dir=rc('dbcan.output_dir', 'dbcan', config=config),
+        db=rc('dbcan.db', "/depot/lindems/data/Databases/cazyme/db", config=config)
     container: "~/.cache/bioinformatics-tools/run_dbcan_light.sif"
     shell:
         """
@@ -269,12 +233,12 @@ rule run_dbcan:
 rule load_dbcan_to_db:
     """Load dbCAN overview results into SQLite database"""
     input:
-        overview=config.get('out_dbcan', 'dbcan/overview.tsv')
+        overview=fixed_path('dbcan', 'overview.tsv', use_stem=False, config=config)
     output:
-        tkn=config.get('out_dbcan_db', 'dbcan/dbcan_db.tkn')
+        tkn=db_token('dbcan', config=config)
     group: "dbcan"
     params:
-        db=config['main_database'],  # Required - no fallback
+        db=rc('main_database', config=config),  # TODO: Add specific error if main_database is not set
         script=os.path.join(WORKFLOW_DIR, "load_to_db.py")
     shell:
         """

--- a/bioinformatics_tools/workflow_tools/output_cache.py
+++ b/bioinformatics_tools/workflow_tools/output_cache.py
@@ -12,6 +12,7 @@ with it — no separate cache directory needed.
 import hashlib
 import logging
 import sqlite3
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -29,6 +30,67 @@ CREATE TABLE IF NOT EXISTS output_cache (
     UNIQUE(input_hash, tool, filename)
 );
 """
+
+
+def _get_connection(db_path: str, timeout: float = 30.0) -> sqlite3.Connection:
+    """Create a SQLite connection configured for network filesystems.
+
+    Args:
+        db_path: Path to the SQLite database file
+        timeout: Connection timeout in seconds (default 30s for NFS)
+
+    Returns:
+        Configured sqlite3.Connection with increased timeout and busy handler
+    """
+    conn = sqlite3.connect(db_path, timeout=timeout)
+
+    # Set busy timeout (milliseconds) - wait up to 30s for locks
+    # This is critical for NFS where lock operations are slow
+    conn.execute(f"PRAGMA busy_timeout={int(timeout * 1000)}")
+
+    return conn
+
+
+def _retry_operation(func, max_retries: int = 3, initial_delay: float = 0.5):
+    """Retry operations that fail with transient disk I/O or lock errors.
+
+    Args:
+        func: Callable to execute
+        max_retries: Maximum number of retry attempts
+        initial_delay: Initial delay between retries (doubles each time)
+
+    Returns:
+        Result of func() if successful
+
+    Raises:
+        sqlite3.OperationalError: If all retries fail
+    """
+    delay = initial_delay
+    last_error = None
+
+    for attempt in range(max_retries):
+        try:
+            return func()
+        except sqlite3.OperationalError as e:
+            last_error = e
+            error_str = str(e).lower()
+
+            # Retry on transient errors
+            if any(err in error_str for err in ["disk i/o error", "database is locked", "unable to open"]):
+                if attempt < max_retries - 1:
+                    LOGGER.warning(
+                        "Database operation failed (attempt %d/%d): %s. Retrying in %.1fs...",
+                        attempt + 1, max_retries, e, delay
+                    )
+                    time.sleep(delay)
+                    delay *= 2  # Exponential backoff
+                else:
+                    LOGGER.error("Database operation failed after %d attempts: %s", max_retries, e)
+            else:
+                # Not a transient error, re-raise immediately
+                raise
+
+    raise last_error
 
 
 def _compute_file_hash(file_path: str) -> str:
@@ -59,7 +121,7 @@ def restore(db_path: str, input_file: str, tool_name: str,
     input_hash = _compute_file_hash(input_file)
     expected = {Path(p).name for p in output_paths}
 
-    conn = sqlite3.connect(db_path)
+    conn = _get_connection(db_path)
     try:
         _ensure_table(conn)
         rows = conn.execute(
@@ -101,7 +163,7 @@ def store(db_path: str, input_file: str, tool_name: str,
     db_path_obj = Path(db_path).expanduser()
     db_path_obj.parent.mkdir(parents=True, exist_ok=True)
 
-    conn = sqlite3.connect(str(db_path_obj))
+    conn = _get_connection(str(db_path_obj))
     try:
         _ensure_table(conn)
         for path in output_paths:
@@ -183,25 +245,43 @@ def log_workflow_run(db_path: str, run_id: str, input_file: str, workflow_name: 
     row_count is always 0 here — it is only meaningful for annotation loaders
     (load_to_db.py). rules_completed holds the number of snakemake rules that
     finished in this run.
+
+    This function is non-fatal: any errors are logged as warnings but do not
+    crash the workflow. The workflow run itself has already succeeded/failed.
     """
-    if not Path(db_path).exists():
-        LOGGER.warning("Cannot write run_log: db not found at %s", db_path)
-        return
-
-    input_hash = _compute_file_hash(input_file)
-    now = datetime.now(timezone.utc).isoformat()
-
-    conn = sqlite3.connect(db_path)
     try:
-        conn.execute(CREATE_RUN_LOG_SQL)
-        conn.execute(
-            "INSERT INTO run_log "
-            "(run_id, input_hash, tool, input_path, row_count, rules_completed, status, loaded_at) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            (run_id, input_hash, workflow_name, input_file, 0, rules_completed, status, now),
-        )
-        conn.commit()
+        if not Path(db_path).exists():
+            LOGGER.warning("Cannot write run_log: db not found at %s", db_path)
+            return
+
+        input_hash = _compute_file_hash(input_file)
+        now = datetime.now(timezone.utc).isoformat()
+
+        def _log_run():
+            """Inner function for retry wrapper."""
+            conn = _get_connection(db_path, timeout=30.0)
+            try:
+                conn.execute(CREATE_RUN_LOG_SQL)
+                conn.execute(
+                    "INSERT INTO run_log "
+                    "(run_id, input_hash, tool, input_path, row_count, rules_completed, status, loaded_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (run_id, input_hash, workflow_name, input_file, 0, rules_completed, status, now),
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        # Retry on transient I/O errors (NFS, lock contention, etc.)
+        _retry_operation(_log_run, max_retries=3, initial_delay=0.5)
+
         LOGGER.info("Logged workflow run: %s run_id=%s status=%s rules_completed=%d (hash %s...)",
                     workflow_name, run_id, status, rules_completed, input_hash[:12])
-    finally:
-        conn.close()
+
+    except Exception as e:
+        # Non-fatal: log the error but don't crash the workflow
+        LOGGER.warning(
+            "Failed to log workflow run to database (non-fatal): %s. "
+            "Workflow execution was %s, but logging failed.",
+            e, status
+        )

--- a/bioinformatics_tools/workflow_tools/workflow.py
+++ b/bioinformatics_tools/workflow_tools/workflow.py
@@ -36,13 +36,13 @@ class WorkflowBase(ProgramBase):
 
         super().__init__()
 
-    def build_executable(self, key: WorkflowKey, config_dict: dict = None, mode='notdev', compute_config: dict = None) -> list[str]:
+    def build_executable(self, key: WorkflowKey, config_overrides: dict = None, mode='notdev', compute_config: dict = None) -> list[str]:
         '''
         Build snakemake command from workflow key and config.
 
         Args:
             key: WorkflowKey defining the workflow
-            config_dict: Snakemake config parameters
+            config_overrides: Only workflow-specific overrides (input_fasta, output_dir, main_database)
             mode: Execution mode ('dev' or other for slurm)
             compute_config: Compute cluster config (account, partition, resources)
         '''
@@ -64,6 +64,12 @@ class WorkflowBase(ProgramBase):
             f'--jobs={max_jobs}',
             '--latency-wait=60'
         ]
+
+        # Check for dry-run/test mode (from config or command line)
+        if self.conf.get('dry_run', False) or self.conf.get('test_only', False):
+            core_command.append('--dry-run')
+            LOGGER.info("Running in DRY-RUN mode - no actual execution")
+
         if mode != 'dev':
             core_command.append('--executor=slurm')
 
@@ -92,9 +98,15 @@ class WorkflowBase(ProgramBase):
             if len(default_resources) > 1:
                 core_command.extend(default_resources)
 
-        # Add config parameters to pass to snakemake
-        if config_dict:
-            config_pairs = [f'{k}={v}' for k, v in config_dict.items()]
+        # Pass original config file(s) to Snakemake to preserve types
+        # This loads the full user config with proper int/bool/nested dict types
+        if hasattr(self, 'config_paths') and self.config_paths:
+            for config_path in self.config_paths:
+                core_command.extend(['--configfile', str(config_path)])
+
+        # Override only workflow-specific values (all strings, so no type issues)
+        if config_overrides:
+            config_pairs = [f'{k}={v}' for k, v in config_overrides.items()]
             core_command.append('--config')
             core_command.extend(config_pairs)
 
@@ -226,7 +238,7 @@ class WorkflowBase(ProgramBase):
             LOGGER.info('Cache restore results: %s', restored)
 
         # Build and run snakemake
-        wf_command = self.build_executable(selected_wf, config_dict=smk_config, mode=mode, compute_config=compute_config)
+        wf_command = self.build_executable(selected_wf, config_overrides=smk_config, mode=mode, compute_config=compute_config)
         LOGGER.info('Running snakemake command: %s', ' '.join(wf_command))
         proc = self._run_subprocess(wf_command)
 
@@ -374,75 +386,51 @@ class WorkflowBase(ProgramBase):
         # Extract and validate compute config for SLURM mode
         compute_config = None
         if mode != 'dev':
-            compute_config = self.conf.get('compute', {}).get('cluster-default', {})
+            compute_config = self.conf.get('compute', {}).get('cluster_default', {})
             slurm_account = compute_config.get('account', '').strip()
             if not slurm_account:
-                LOGGER.error('compute.cluster-default.account not set in config. Add account: <your-slurm-account> to your ~/.config/bioinformatics-tools/config.yaml')
+                LOGGER.error('compute.cluster_default.account not set in config. Add account: <your-slurm-account> to your ~/.config/bioinformatics-tools/config.yaml')
                 self.failed('SLURM account configuration is required for cluster execution')
                 return 1
 
         stem = Path(input_file).stem
         prefix = self._output_prefix()
 
-        # Output paths
-        out_prodigal = f"{prefix}prodigal/{stem}-prodigal.tkn"
+        # Only pass workflow-specific overrides to Snakemake
+        # The full config is loaded via --configfile from self.config_paths
+        config_overrides = {
+            'input_fasta': input_file,
+            'output_dir': prefix.rstrip('/'),
+            'main_database': main_database,
+        }
+
+        # Cache map - compute paths using same logic as workflow_helpers
+        # Note: These paths must match what margie.smk generates
+        out_prodigal_gff = f"{prefix}prodigal/{stem}-prodigal.gff"
         out_prodigal_faa = f"{prefix}prodigal/{stem}-prodigal.faa"
         out_prodigal_db = f"{prefix}prodigal/{stem}-prodigal_db.tkn"
-        out_pfam = f"{prefix}pfam/{stem}-pfam.tkn"
+        out_pfam = f"{prefix}pfam/pfam.tsv"
         out_pfam_db = f"{prefix}pfam/{stem}-pfam_db.tkn"
-        out_cog = f"{prefix}cog/{stem}-cog.tkn"
+        out_cog_tkn = f"{prefix}cog/cog.tkn"
         out_cog_classify = f"{prefix}cog/cog_classify.tsv"
         out_cog_count = f"{prefix}cog/cog_count.tsv"
         out_cog_db = f"{prefix}cog/{stem}-cog_db.tkn"
-        cog_outdir = f"{prefix}cog"
-        out_kofam = f"{prefix}kofam/{stem}-kofam.tkn"
+        out_kofam = f"{prefix}kofam/kofam.tsv"
         out_kofam_db = f"{prefix}kofam/{stem}-kofam_db.tkn"
         out_uniop = f"{prefix}uniop/operons.tsv"
-        out_uniop_db = f"{prefix}uniop/uniop_db.tkn"
+        out_uniop_db = f"{prefix}uniop/{stem}-uniop_db.tkn"
         out_dbcan = f"{prefix}dbcan/overview.tsv"
-        out_dbcan_db = f"{prefix}dbcan/dbcan_db.tkn"
+        out_dbcan_db = f"{prefix}dbcan/{stem}-dbcan_db.tkn"
 
-        smk_config = {
-            'input_fasta': input_file,
-            'out_prodigal': out_prodigal,
-            'out_prodigal_faa': out_prodigal_faa,
-            'out_prodigal_db': out_prodigal_db,
-            'out_pfam': out_pfam,
-            'out_pfam_db': out_pfam_db,
-            'out_cog': out_cog,
-            'out_cog_classify': out_cog_classify,
-            'out_cog_count': out_cog_count,
-            'out_cog_db': out_cog_db,
-            'cog_outdir': cog_outdir,
-            'out_uniop': out_uniop,
-            'out_uniop_db': out_uniop_db,
-            'out_dbcan': out_dbcan,
-            'out_dbcan_db': out_dbcan_db,
-            'out_kofam': out_kofam,
-            'out_kofam_db': out_kofam_db,
-            'main_database': main_database,
-            # Hierarchical tool configs - pass entire sections to snakemake
-            'prodigal': self.conf.get('prodigal', {}),
-            'pfam': self.conf.get('pfam', {}),
-            'cog': self.conf.get('cog', {}),
-            'dbcan': self.conf.get('dbcan', {}),
-            'kofam': self.conf.get('kofam', {}),
-            'uniop': self.conf.get('uniop', {}),
-        }
-
+        # Cache map - each tool includes ALL files (intermediates + token)
+        # This ensures when we have a cache HIT, we restore everything Snakemake needs
         cache_map = {
-            'prodigal': [out_prodigal, out_prodigal_faa],
-            'prodigal_db': [out_prodigal_db],
-            'pfam': [out_pfam],
-            'pfam_db': [out_pfam_db],
-            'cog': [out_cog, out_cog_classify, out_cog_count],
-            'cog_db': [out_cog_db],
-            'kofam': [out_kofam],
-            'kofam_db': [out_kofam_db],
-            'uniop': [out_uniop],
-            'uniop_db': [out_uniop_db],
-            'dbcan': [out_dbcan],
-            'dbcan_db': [out_dbcan_db],
+            'prodigal': [out_prodigal_gff, out_prodigal_faa, out_prodigal_db],
+            'pfam': [out_pfam, out_pfam_db],
+            'cog': [out_cog_tkn, out_cog_classify, out_cog_count, out_cog_db],
+            'kofam': [out_kofam, out_kofam_db],
+            'uniop': [out_uniop, out_uniop_db],
+            'dbcan': [out_dbcan, out_dbcan_db],
         }
 
-        self._run_pipeline('margie', smk_config, cache_map, mode=mode, compute_config=compute_config)
+        self._run_pipeline('margie', config_overrides, cache_map, mode=mode, compute_config=compute_config)

--- a/bioinformatics_tools/workflow_tools/workflow_helpers.py
+++ b/bioinformatics_tools/workflow_tools/workflow_helpers.py
@@ -1,0 +1,209 @@
+"""
+Shared utilities for Snakemake workflows.
+
+Provides configuration helpers and standardized path generation.
+Import into Snakemake files to access config and generate output paths.
+"""
+from pathlib import Path
+
+
+def rc(key, default=None, config=None):
+    """
+    Rule Config: Get config value using dot notation for nested keys.
+
+    Supports arbitrary nesting via dot notation:
+
+    Example config:
+        prodigal:
+          threads: 1
+          mem_mb: 2048
+        compute:
+          cluster_default:
+            account: myaccount
+            partition: cpu
+
+    Usage in rules:
+        threads: rc('prodigal.threads', 1, config=config)
+        account: rc('compute.cluster_default.account', None, config=config)
+        simple: rc('input_fasta', config=config)
+
+    Args:
+        key: Config key using dot notation (e.g., 'prodigal.mem_mb')
+        default: Default value if not found in config
+        config: The Snakemake config dict
+
+    Returns:
+        The config value or default if not set
+    """
+    if config is None:
+        raise ValueError("config parameter is required")
+
+    # Split key by dots and traverse nested dict
+    parts = key.split('.')
+    value = config
+
+    for part in parts:
+        if isinstance(value, dict) and part in value:
+            value = value[part]
+        else:
+            return default
+
+    return value
+
+
+def get_stem(config):
+    """
+    Extract stem (filename without extension) from input file.
+    """
+    input_file = config.get('input_fasta', 'output')
+    return Path(input_file).stem
+
+
+def get_prefix(config):
+    """
+    Get output directory prefix with trailing slash.
+    Always returns an absolute path.
+
+    Example:
+        output_dir: './tmp-2'
+        --> '/home/ddeemer/git-repos/bioinformatics-tools/tmp-2/'
+
+        output_dir: '/results/2024-03-24'
+        --> '/results/2024-03-24/'
+    """
+    output_dir = config.get('output_dir', '')
+    if not output_dir:
+        return ''
+
+    # Convert to absolute path and add trailing slash
+    abs_path = Path(output_dir).resolve()
+    return f"{abs_path}/"
+
+
+def fixed_path(tool, filename='', use_stem=True, config=None) -> str:
+    """
+    Generate output paths for fixed filenames (non-configurable).
+
+    Use this for tool outputs with fixed, unchanging filenames like:
+    - pfam.tsv (always named 'pfam.tsv')
+
+    For user-configurable outputs, use tool_output() instead.
+
+    Generates paths using the pattern:
+        {prefix}{tool}/{stem}-{filename}  (if use_stem=True)
+        {prefix}{tool}/{filename}          (if use_stem=False)
+
+    Examples:
+        # With stem
+        fixed_path('prodigal', 'prodigal.faa', config=config)
+        # config: input_fasta='ecoli.fasta', output_dir='results/'
+        # 'results/prodigal/ecoli-prodigal.faa'
+
+        # Without stem (fixed filename)
+        fixed_path('pfam', 'pfam.tsv', use_stem=False, config=config)
+        # 'results/pfam/pfam.tsv'
+    """
+    if config is None:
+        raise ValueError("config parameter is required")
+
+    prefix = get_prefix(config)
+    stem = get_stem(config)
+
+    # Build filename
+    if use_stem and filename and stem:
+        final_filename = f"{stem}-{filename}"
+    else:
+        final_filename = filename
+
+    return f"{prefix}{tool}/{final_filename}"
+
+
+def tool_output(config_key, suffix, config=None) -> str:
+    """
+    Generate standardized output path with support for user-specified filenames.
+
+    CONVENTION: The first part of config_key is ALWAYS the tool/directory name.
+    This supports arbitrary nesting while maintaining predictable directory structure.
+
+    Example configs:
+        # Simple case
+        prodigal:
+          output: my_custom_genes
+
+        # Nested case (supports versioning, variants, etc.)
+        prodigal:
+          version1:
+            output: custom_v1
+            threads: 4
+          version2:
+            output: custom_v2
+
+    Usage:
+        tool_output('prodigal.output', 'gff', config=config)
+        → Directory: 'prodigal/', Lookup: config['prodigal']['output']
+
+        tool_output('prodigal.version1.output', 'gff', config=config)
+        → Directory: 'prodigal/', Lookup: config['prodigal']['version1']['output']
+
+    Args:
+        config_key: Dot-notation config key where first part = tool/directory name
+                   (e.g., 'prodigal.output', 'prodigal.v1.output')
+        suffix: File extension (e.g., 'gff', 'faa')
+        config: The Snakemake config dict
+
+    Examples:
+        # User specifies custom filename (simple)
+        # config: prodigal.output = 'my_genes'
+        tool_output('prodigal.output', 'gff', config=config)
+        → 'results/prodigal/my_genes.gff'
+
+        # User specifies custom filename (nested)
+        # config: prodigal.v1.output = 'custom_v1'
+        tool_output('prodigal.v1.output', 'gff', config=config)
+        → 'results/prodigal/custom_v1.gff'
+
+        # User doesn't specify, auto-generate with stem
+        # config: input_fasta = 'ecoli.fasta'
+        tool_output('prodigal.output', 'gff', config=config)
+        → 'results/prodigal/ecoli-prodigal.gff'
+    """
+    if config is None:
+        raise ValueError("config parameter is required")
+
+    # Parse config_key - FIRST PART is always the tool/directory name
+    parts = config_key.split('.')
+    if len(parts) < 1:
+        raise ValueError(f"config_key must have at least one part, got: {config_key}")
+
+    tool = parts[0]  # First part determines directory structure
+
+    # Check if user specified a custom filename via rc() (supports arbitrary nesting)
+    custom_filename = rc(config_key, None, config=config)
+
+    prefix = get_prefix(config)
+
+    if custom_filename:
+        # User specified custom filename: {prefix}{tool}/{custom_filename}.{suffix}
+        return f"{prefix}{tool}/{custom_filename}.{suffix}"
+    else:
+        # Auto-generate with stem: {prefix}{tool}/{stem}-{tool}.{suffix}
+        stem = get_stem(config)
+        return f"{prefix}{tool}/{stem}-{tool}.{suffix}"
+
+
+def db_token(tool, config=None):
+    """
+    Generate database token path: {tool}/{stem}-{tool}_db.tkn
+
+    Args:
+        tool: Tool name (e.g., 'prodigal', 'pfam')
+        config: The Snakemake config dict
+
+    Returns:
+        Path to database token file
+
+    Example:
+        db_token('prodigal', config=config)
+        → 'results/prodigal/ecoli-prodigal_db.tkn'
+    """
+    return fixed_path(tool, f'{tool}_db.tkn', use_stem=True, config=config)

--- a/bioinformatics_tools/workflow_tools/workflow_registry.py
+++ b/bioinformatics_tools/workflow_tools/workflow_registry.py
@@ -12,32 +12,32 @@ from bioinformatics_tools.workflow_tools.models import WorkflowKey
 # These are needed for ANY workflow running via SLURM, not workflow-specific
 REQUIRED_SYSTEM_PARAMS = [
     {
-        'param': 'compute.cluster-default.account',
+        'param': 'compute.cluster_default.account',
         'default': None,
         'description': 'SLURM account for job submission (REQUIRED for cluster execution)',
         'type': 'string',
         'required': True
     },
     {
-        'param': 'compute.cluster-default.partition',
+        'param': 'compute.cluster_default.partition',
         'default': 'cpu',
         'description': 'SLURM partition/queue for job submission',
         'type': 'string'
     },
     {
-        'param': 'compute.cluster-default.default_runtime',
+        'param': 'compute.cluster_default.default_runtime',
         'default': 30,
         'description': 'Default runtime limit in minutes for SLURM jobs',
         'type': 'int'
     },
     {
-        'param': 'compute.cluster-default.default_mem_mb',
+        'param': 'compute.cluster_default.default_mem_mb',
         'default': 4000,
         'description': 'Default memory limit in MB for SLURM jobs',
         'type': 'int'
     },
     {
-        'param': 'compute.cluster-default.max_jobs',
+        'param': 'compute.cluster_default.max_jobs',
         'default': 5,
         'description': 'Maximum number of concurrent SLURM jobs',
         'type': 'int'


### PR DESCRIPTION
# Changes

**config**

  - Nested dictionary support in conf.get() - Added ability to access nested config values with dot notation (e.g., compute.cluster_default.account)
  - Multiple config file support - CLI now accepts multiple --config arguments that are merged in order
  - Config piping to Snakemake - New rc() helper function in workflow_helpers.py to cleanly extract and validate config values with defaults before passing to Snakemake rules
  - Standardized parameter names - Changed config keys from kebab-case (cluster-default) to snake_case (cluster_default) for consistency

  **SQLite Reliability on NFS**

  - Non-fatal workflow logging - log_workflow_run() now catches and logs errors instead of crashing workflows
  - Retry logic with exponential backoff - Added _retry_operation() helper that retries transient "disk I/O error" and "database is locked" failures up to 3 times
  - Extended timeouts - Increased SQLite connection timeout from 5s to 30s for better NFS compatibility
  - Applied to all database operations - New _get_connection() helper used consistently across restore(), store(), and log_workflow_run()

## Other

  - Workflows can now be configured more flexibly with multiple layered config files
  - Database operations are much more reliable on shared NFS mounts
  - Workflow success is no longer blocked by transient database logging failures